### PR TITLE
Update Crello dataset to v2

### DIFF
--- a/docs/crello-dataset.md
+++ b/docs/crello-dataset.md
@@ -3,14 +3,12 @@
 Crello dataset is compiled for the study of vector graphic documents. The
 dataset contains document meta-data such as canvas size and pre-rendered
 elements such as images or text boxes. The original templates was collected from
-[crello.com](https://crello.com) and converted to low-resolution format suitable
-for machine learning analysis.
-
-![Preview](preview.svg)
+[crello.com](https://crello.com) (now [create.vista.com](https://create.vista.com))
+and converted to low-resolution format suitable for machine learning analysis.
 
 ## Download
 
-- [Full dataset (3GB)](https://storage.cloud.google.com/ailab-public/canvas-vae/crello-dataset-v1.zip)
+- [Crello dataset v2 release (3.9 GB)](https://storage.cloud.google.com/ailab-public/canvas-vae/crello-dataset-v2.zip)
 
 ## Content
 
@@ -51,7 +49,7 @@ The schema is the following.
 
 | Field       | Type    | Shape | Description                                                          |
 | ----------- | ------- | ----- | -------------------------------------------------------------------- |
-| type        | string  | ()    | Element type, such as vector shape, image, or text placeholder       |
+| type        | string  | ()    | Element type, such as vector shape, image, or text                   |
 | left        | float32 | ()    | Element left position normalized to [0, 1] range w.r.t. canvas_width |
 | top         | float32 | ()    | Element top position normalized to [0, 1] range w.r.t. canvas_height |
 | width       | float32 | ()    | Element width normalized to [0, 1] range w.r.t. canvas_width         |
@@ -59,9 +57,20 @@ The schema is the following.
 | color       | int64   | (3,)  | Extracted main RGB color of the element                              |
 | opacity     | float32 | ()    | Opacity in [0, 1] range                                              |
 | image_bytes | string  | ()    | Pre-rendered 256x256 preview of the element encoded in PNG format    |
+| text        | string  | ()    | Text content in UTF-8 encoding for text element                      |
+| font        | string  | ()    | Font family name for text element                                    |
+| font_size   | float32 | ()    | Font size (height) in pixels                                         |
+| text_align  | string  | ()    | Horizontal text alignment, left, center, right for text element      |
+| angle       | float32 | ()    | Element rotation angle (radian) w.r.t. the center of the element     |
 
 Note that the color and pre-rendered images are do not necessarily accurately
 reproduce the original design templates.
+The original template is accessible at the following URL if still available.
+
+```
+https://create.vista.com/artboard/?template=<template_id>
+```
+
 
 `count.json`
 
@@ -93,11 +102,15 @@ Dictionaries of vocabulary-frequency for each string field in the dataset.
   "category": {/* ... */},
   "format": {/* ... */},
   "group": {/* ... */},
+  "font": {/* ... */},
+  "text_align": {/* ... */},
   "type": {/* ... */}
 }
 ```
 
 ## Python example
+
+### Parsing
 
 The following demonstrates how to convert TFRecord to generic python structure.
 
@@ -107,14 +120,14 @@ from typing import Any, Dict
 
 def extract_feature(feature: tf.train.Feature) -> Any:
     """Convert tf.train.Feature"""
-    if feature.HasField('int64_list'):
+    if feature.HasField("int64_list"):
         value = [x for x in feature.int64_list.value]
-    elif feature.HasField('bytes_list'):
+    elif feature.HasField("bytes_list"):
         value = [x for x in feature.bytes_list.value]
-    elif feature.HasField('float_list'):
+    elif feature.HasField("float_list"):
         value = [x for x in feature.float_list.value]
     else:
-        raise ValueError('feature is empty')
+        raise ValueError("feature is empty")
     return value[0] if len(value) == 1 else value
 
 
@@ -131,7 +144,7 @@ def extract_sequence_example(serialized: bytes) -> Dict[str, Any]:
     return output
 
 
-dataset = tf.data.Dataset.list_files('train-*.tfrecord')
+dataset = tf.data.Dataset.list_files("train-*.tfrecord")
 dataset = tf.data.TFRecordDataset(dataset)
 for example in dataset.take(1).as_numpy_iterator():
     example = extract_sequence_example(example)
@@ -146,33 +159,38 @@ Alternatively, the following approach can be used to extract specified fields.
 import tensorflow as tf
 from typing import Any, Dict
 
-def parse(serialized: bytes) -> Dict[str, Any]:
+def parse(serialized: bytes) -> Dict[str, tf.Tensor]:
     """Explicitly parse specified fields."""
     context, sequence, _ = tf.io.parse_sequence_example(
         serialized,
         context_features={
-            'id': tf.io.FixedLenFeature((), tf.string),
-            'group': tf.io.FixedLenFeature((), tf.string),
-            'format': tf.io.FixedLenFeature((), tf.string),
-            'category': tf.io.FixedLenFeature((), tf.string),
-            'canvas_height': tf.io.FixedLenFeature((), tf.int64),
-            'canvas_width': tf.io.FixedLenFeature((), tf.int64),
-            'length': tf.io.FixedLenFeature((), tf.int64),
+            "id": tf.io.FixedLenFeature((), tf.string),
+            "group": tf.io.FixedLenFeature((), tf.string),
+            "format": tf.io.FixedLenFeature((), tf.string),
+            "category": tf.io.FixedLenFeature((), tf.string),
+            "canvas_height": tf.io.FixedLenFeature((), tf.int64),
+            "canvas_width": tf.io.FixedLenFeature((), tf.int64),
+            "length": tf.io.FixedLenFeature((), tf.int64),
         },
         sequence_features={
-            'type': tf.io.FixedLenSequenceFeature((), tf.string),
-            'left': tf.io.FixedLenSequenceFeature((), tf.float32),
-            'top': tf.io.FixedLenSequenceFeature((), tf.float32),
-            'width': tf.io.FixedLenSequenceFeature((), tf.float32),
-            'height': tf.io.FixedLenSequenceFeature((), tf.float32),
-            'color': tf.io.FixedLenSequenceFeature((3,), tf.int64),
-            'opacity': tf.io.FixedLenSequenceFeature((), tf.float32),
-            'image_bytes': tf.io.FixedLenSequenceFeature((), tf.string),
+            "type": tf.io.FixedLenSequenceFeature((), tf.string),
+            "left": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "top": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "width": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "height": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "color": tf.io.FixedLenSequenceFeature((3,), tf.int64),
+            "opacity": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "image_bytes": tf.io.FixedLenSequenceFeature((), tf.string),
+            "text": tf.io.FixedLenSequenceFeature((), tf.string),
+            "font": tf.io.FixedLenSequenceFeature((), tf.string),
+            "font_size": tf.io.FixedLenSequenceFeature((), tf.float32),
+            "text_align": tf.io.FixedLenSequenceFeature((), tf.string),
+            "angle": tf.io.FixedLenSequenceFeature((), tf.float32),
         })
     return {**context, **sequence}
 
 
-dataset = tf.data.Dataset.list_files('train-*.tfrecord')
+dataset = tf.data.Dataset.list_files("train-*.tfrecord")
 dataset = tf.data.TFRecordDataset(dataset)
 dataset = dataset.map(parse)
 
@@ -181,6 +199,54 @@ for example in dataset.take(1).as_numpy_iterator():
 
 print(example)
 ```
+
+### Visualization
+
+The parsed example can be visualized in the following approach. Note the
+following does not guarantee the similar appearance to the original template.
+
+```python
+import io
+import numpy as np
+import skia
+import tensorflow as tf
+from typing import Any, Dict
+
+def render(example: Dict[str, tf.Tensor], max_size: float=512.) -> bytes:
+    """Render parsed sequence example onto an image and return as PNG bytes."""
+    canvas_width = example["canvas_width"].numpy()
+    canvas_height = example["canvas_height"].numpy()
+
+    scale = min(1.0, max_size / canvas_width, max_size / canvas_height)
+
+    surface = skia.Surface(int(scale * canvas_width), int(scale * canvas_height))
+    with surface as canvas:
+        canvas.scale(scale, scale)
+        for index in range(example["length"].numpy()):
+            with io.BytesIO(example["image_bytes"][index].numpy()) as f:
+                image = skia.Image.open(f)
+            left = example["left"][index].numpy() * canvas_width
+            top = example["top"][index].numpy() * canvas_height
+            width = example["width"][index].numpy() * canvas_width
+            height = example["height"][index].numpy() * canvas_height
+            rect = skia.Rect.MakeXYWH(left, top, width, height)
+
+            angle = example["angle"][index].numpy()
+            if angle != 0:
+                degree = 180. * angle / np.pi
+                canvas.save()
+                canvas.rotate(degree, left + width / 2., top + height / 2.)
+
+            canvas.drawImageRect(image, rect)
+            if angle != 0:
+                canvas.restore()
+
+    image = surface.makeImageSnapshot()
+    with io.BytesIO() as f:
+        image.save(f, skia.kPNG)
+        return f.getvalue()
+```
+
 
 ## Citation
 
@@ -195,13 +261,22 @@ print(example)
 
 ## License
 
-The origin of the dataset is [crello.com](https://crello.com). The distributor
-("We") do not own the copyrights of the original design templates. By using
-Crello dataset, the user of this dataset ("You") must agree to the
-[Crello License Agreements](https://crello.com/faq/legal/licensing/license_agreements/).
+The origin of the dataset is [create.vista.com](https://create.vista.com) (formally, `crello.com`).
+The distributor ("We") do not own the copyrights of the original design templates.
+By using Crello dataset, the user of this dataset ("You") must agree to the
+[VistaCreate License Agreements](https://create.vista.com/faq/legal/licensing/license_agreements/).
 
 The dataset is distributed under [CDLA-Permissive-2.0 license](https://cdla.dev/permissive-2-0/).
 
+**Note**
+
+We do not re-distribute the original files as we are not allowed by terms.
+
 ## Versions
 
-- 1.0: initial release (Aug 24, 2021)
+2.0: v2 release (May 26, 2022)
+
+- Adds `text`, `font`, `font_size`, `text_align`, and `angle` sequence attributes.
+- Include rendered text element in `image_bytes`.
+
+1.0: v1 release (Aug 24, 2021)


### PR DESCRIPTION
This PR includes the following updates to the Crello dataset.

**Changes**

- Add `text`, `font`, `font_size`, `text_align`, and `angle` sequence attributes.
- Include rendered text element in `image_bytes`.
- Update `crello.com` with `create.vista.com` where applicable.